### PR TITLE
Added contact email to first subsection of terms.md to make contact with ADN easy

### DIFF
--- a/terms.md
+++ b/terms.md
@@ -6,7 +6,7 @@ We asked our attorney to help us craft some terms that outline, with the least a
 
 ## Accepting these Terms
 
-If you access or use the Service, it means you agree to be bound by all of the terms below. So, before you use the Service, please read all of the terms. If you don't agree to all of the terms below, please do not use the Service. Also, if a term does not make sense to you, please let us know.
+If you access or use the Service, it means you agree to be bound by all of the terms below. So, before you use the Service, please read all of the terms. If you don't agree to all of the terms below, please do not use the Service. Also, if a term does not make sense to you, please feel free to contact us at privacy@app.net.
 
 ## Changes to these Terms
 


### PR DESCRIPTION
In the first subsection about accepting the privacy, I included an email address instead of just "please contact us." I doubt most, if any, users will have problems with the terms. But if they do, it should be easy to find the correct contact address through which to reach out and receive prompt response. Maybe best to list it here?
